### PR TITLE
Makes batch size configurable

### DIFF
--- a/scoutbot/tile_batched/main.py
+++ b/scoutbot/tile_batched/main.py
@@ -30,7 +30,7 @@ class Yolov8DetectionModel(Yolov8DetectionModelBase):
     def __init__(self, *args, batch_size: Optional[int] = None, **kwargs):
         """
         Initializes the Yolov8DetectionModel with an optional batch size and additional arguments.
-        
+
         Args:
             *args: Positional arguments to be passed to the base class.
             batch_size (Optional[int]): Batch size for inference.
@@ -42,7 +42,7 @@ class Yolov8DetectionModel(Yolov8DetectionModelBase):
     def perform_inference(self, images: List[np.ndarray], batch_size: Optional[int] = None):
         """
         Perform inference using the model and store predictions.
-        
+
         Args:
             images (List[np.ndarray]): List of images as numpy arrays for prediction.
             batch_size (Optional[int]): Batch size for inference, overrides class-level batch size if provided.
@@ -57,14 +57,14 @@ class Yolov8DetectionModel(Yolov8DetectionModelBase):
         for i in range(0, len(images), batch_size):
             batch_images = images[i:i + batch_size]
             preds = self.model.predict(
-                source=batch_images, 
-                verbose=False, 
+                source=batch_images,
+                verbose=False,
                 device=self.device
             )
             all_preds.extend(preds)
 
         prediction_result = [
-            result.boxes.data[result.boxes.data[:, 4] >= self.confidence_threshold] 
+            result.boxes.data[result.boxes.data[:, 4] >= self.confidence_threshold]
             for result in all_preds
         ]
 

--- a/scoutbot/tile_batched/main.py
+++ b/scoutbot/tile_batched/main.py
@@ -24,15 +24,21 @@ POSTPROCESS_NAME_TO_CLASS = {
     "LSNMS": LSNMSPostprocess,
 }
 
+DETECTOR_BATCH_SIZE = int(os.getenv('DETECTOR_BATCH_SIZE', 128))
 
 class Yolov8DetectionModel(Yolov8DetectionModelBase):
-    def perform_inference(self, images: List[np.ndarray], batch_size=128):
+
+    def __init__(self, batch_size=None):
+        self.batch_size = batch_size or int(os.getenv('DETECTOR_BATCH_SIZE', 128))
+
+    def perform_inference(self, images: List[np.ndarray], batch_size=None):
         """
         Prediction is performed using self.model and the prediction result is set to self._original_predictions.
         Args:
-            image: np.ndarray
-                A numpy array that contains the image to be predicted. 3 channel image should be in RGB order.
+            images: List[np.ndarray]
+                A list of numpy arrays that contain the images to be predicted. 3 channel images should be in RGB order.
         """
+        batch_size = batch_size or self.batch_size
 
         # Confirm model is loaded
         if self.model is None:
@@ -42,7 +48,6 @@ class Yolov8DetectionModel(Yolov8DetectionModelBase):
         for i in range(0, len(images), batch_size):
             batch_images = images[i:i + batch_size]
             preds = self.model.predict(source=batch_images, verbose=False, device=self.device)
-
             all_preds.extend(preds)
 
         prediction_result = [

--- a/scoutbot/tile_batched/main.py
+++ b/scoutbot/tile_batched/main.py
@@ -1,12 +1,11 @@
-import time
-import numpy as np
 import logging
 import os
-
+import time
 from typing import List, Optional, Union, Dict
 
-from sahi.prediction import ObjectPrediction
+import numpy as np
 
+from sahi.prediction import ObjectPrediction
 from sahi.postprocess.combine import (
     GreedyNMMPostprocess,
     LSNMSPostprocess,
@@ -14,7 +13,6 @@ from sahi.postprocess.combine import (
     NMSPostprocess,
     PostprocessPredictions,
 )
-
 from sahi.models.yolov8 import Yolov8DetectionModel as Yolov8DetectionModelBase
 
 POSTPROCESS_NAME_TO_CLASS = {
@@ -29,15 +27,25 @@ DETECTOR_BATCH_SIZE = int(os.getenv('DETECTOR_BATCH_SIZE', 128))
 
 class Yolov8DetectionModel(Yolov8DetectionModelBase):
 
-    def __init__(self, batch_size=None):
-        self.batch_size = batch_size or int(os.getenv('DETECTOR_BATCH_SIZE', 128))
-
-    def perform_inference(self, images: List[np.ndarray], batch_size=None):
+    def __init__(self, *args, batch_size: Optional[int] = None, **kwargs):
         """
-        Prediction is performed using self.model and the prediction result is set to self._original_predictions.
+        Initializes the Yolov8DetectionModel with an optional batch size and additional arguments.
+        
         Args:
-            images: List[np.ndarray]
-                A list of numpy arrays that contain the images to be predicted. 3 channel images should be in RGB order.
+            *args: Positional arguments to be passed to the base class.
+            batch_size (Optional[int]): Batch size for inference.
+            **kwargs: Additional keyword arguments to be passed to the base class.
+        """
+        self.batch_size = batch_size or DETECTOR_BATCH_SIZE
+        super().__init__(*args, **kwargs)
+
+    def perform_inference(self, images: List[np.ndarray], batch_size: Optional[int] = None):
+        """
+        Perform inference using the model and store predictions.
+        
+        Args:
+            images (List[np.ndarray]): List of images as numpy arrays for prediction.
+            batch_size (Optional[int]): Batch size for inference, overrides class-level batch size if provided.
         """
         batch_size = batch_size or self.batch_size
 
@@ -48,11 +56,16 @@ class Yolov8DetectionModel(Yolov8DetectionModelBase):
         all_preds = []
         for i in range(0, len(images), batch_size):
             batch_images = images[i:i + batch_size]
-            preds = self.model.predict(source=batch_images, verbose=False, device=self.device)
+            preds = self.model.predict(
+                source=batch_images, 
+                verbose=False, 
+                device=self.device
+            )
             all_preds.extend(preds)
 
         prediction_result = [
-            result.boxes.data[result.boxes.data[:, 4] >= self.confidence_threshold] for result in all_preds
+            result.boxes.data[result.boxes.data[:, 4] >= self.confidence_threshold] 
+            for result in all_preds
         ]
 
         self._original_predictions = prediction_result

--- a/scoutbot/tile_batched/main.py
+++ b/scoutbot/tile_batched/main.py
@@ -26,6 +26,7 @@ POSTPROCESS_NAME_TO_CLASS = {
 
 DETECTOR_BATCH_SIZE = int(os.getenv('DETECTOR_BATCH_SIZE', 128))
 
+
 class Yolov8DetectionModel(Yolov8DetectionModelBase):
 
     def __init__(self, batch_size=None):


### PR DESCRIPTION
Configured by setting the env value `DETECTOR_BATCH_SIZE`

Example:

`export DETECTOR_BATCH_SIZE=8; scoutbot batch --config v3-cls ~/workspace/test/*.JPG
`
Default value is 256