### PR TITLE
Fix for migration to upload-artifact@v4:  overwrite if same name.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./dist/*.whl
+          overwrite: true
 
   build_sdist:
     name: Build source distribution


### PR DESCRIPTION
Older versions of upload-artifact would silently overwrite if there was a name collision.  this behavior changed in version 4.  I've added the option to keep the legacy behavior.   