### PR TITLE
Add classes method

### DIFF
--- a/scoutbot/__init__.py
+++ b/scoutbot/__init__.py
@@ -62,7 +62,7 @@ QUIET = not utils.VERBOSE
 
 
 from scoutbot import agg, loc, tile, wic, tile_batched  # NOQA
-from scoutbot.loc import CONFIGS as LOC_CONFIGS
+from scoutbot.loc import CONFIGS as LOC_CONFIGS # NOQA
 
 # from tile_batched.models import Yolov8DetectionModel
 # from tile_batched import get_sliced_prediction_batched
@@ -460,6 +460,7 @@ def batch_v3(
 
     return wic_list, detects_list
 
+
 def get_classes():
     classes = set()
     for config in ['v3', 'v3-cls']:
@@ -478,7 +479,6 @@ def get_classes():
 
     classes = list(classes)
     return classes
-
 
 
 def example():

--- a/scoutbot/__init__.py
+++ b/scoutbot/__init__.py
@@ -62,6 +62,7 @@ QUIET = not utils.VERBOSE
 
 
 from scoutbot import agg, loc, tile, wic, tile_batched  # NOQA
+from scoutbot.loc import CONFIGS as LOC_CONFIGS
 
 # from tile_batched.models import Yolov8DetectionModel
 # from tile_batched import get_sliced_prediction_batched
@@ -458,6 +459,26 @@ def batch_v3(
         detects_list.append(detects)
 
     return wic_list, detects_list
+
+def get_classes():
+    classes = set()
+    for config in ['v3', 'v3-cls']:
+        yolov8_model_path = loc.fetch(config=config)
+        model = tile_batched.Yolov8DetectionModel(
+            model_path=yolov8_model_path,
+            confidence_threshold=0.5,
+            device='cpu',
+        )
+        model_classes = list(model.category_names)
+        classes.update(model_classes)
+
+    for config in ['phase1', 'mvp']:
+        model_classes = LOC_CONFIGS[config]['classes']
+        classes.update(model_classes)
+
+    classes = list(classes)
+    return classes
+
 
 
 def example():

--- a/scoutbot/scoutbot.py
+++ b/scoutbot/scoutbot.py
@@ -29,13 +29,16 @@ model_option = [
     ),
 ]
 
-shared_options = [
+output_option = [
     click.option(
         '--output',
         help='Path to output JSON (if unspecified, results are printed to screen)',
         default=None,
         type=str,
     ),
+]
+
+shared_options = [
     click.option(
         '--backend_device',  # torch backend device
         help='Specifies the device for inference (see YOLO and PyTorch documentation for more information).',
@@ -93,6 +96,7 @@ def add_options(options):
 )
 @add_options(model_option)
 @add_options(shared_options)
+@add_options(output_option)
 def pipeline(
     filepath,
     config,
@@ -183,6 +187,7 @@ def pipeline(
 )
 @add_options(model_option)
 @add_options(shared_options)
+@add_options(output_option)
 def batch(
     filepaths,
     config,
@@ -301,12 +306,18 @@ def example():
 
 
 @click.command('get_classes')
-def get_classes():
+@add_options(output_option)
+def get_classes(output):
     """
     Run a test of the pipeline on an example image with the default configuration.
     """
     classes = scoutbot.get_classes()
-    print(ut.repr3(classes))
+    log.debug('Outputting classes list...')
+    if output:
+        with open(output, 'w') as outfile:
+            json.dump(classes, outfile)
+    else:
+        print(ut.repr3(classes))
 
 
 @click.group()

--- a/scoutbot/scoutbot.py
+++ b/scoutbot/scoutbot.py
@@ -299,6 +299,13 @@ def example():
     """
     scoutbot.example()
 
+@click.command('get_classes')
+def get_classes():
+    """
+    Run a test of the pipeline on an example image with the default configuration.
+    """
+    classes = scoutbot.get_classes()
+    print(ut.repr3(classes))
 
 @click.group()
 def cli():
@@ -312,6 +319,7 @@ cli.add_command(pipeline)
 cli.add_command(batch)
 cli.add_command(fetch)
 cli.add_command(example)
+cli.add_command(get_classes)
 
 if __name__ == '__main__':
     cli()

--- a/scoutbot/scoutbot.py
+++ b/scoutbot/scoutbot.py
@@ -299,6 +299,7 @@ def example():
     """
     scoutbot.example()
 
+
 @click.command('get_classes')
 def get_classes():
     """
@@ -306,6 +307,7 @@ def get_classes():
     """
     classes = scoutbot.get_classes()
     print(ut.repr3(classes))
+
 
 @click.group()
 def cli():
@@ -320,6 +322,7 @@ cli.add_command(batch)
 cli.add_command(fetch)
 cli.add_command(example)
 cli.add_command(get_classes)
+
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
Method to pull all possible output class names from scoutbot. To be used for integration with scout. See https://github.com/WildMeOrg/scout/issues/70

Example usage: 
`scoutbot get_classes`  - dumps a JSON list to stdout 
`scoutbot get_classes --output /path/to/file.json` - dumps a JSON list to a new file

