### PR TITLE
Another overwrite fix for migration to upload-artifact@v4

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./dist/*.tar.gz
+          overwrite: true
 
   test_wheel:
     needs: [build_wheels, build_sdist]


### PR DESCRIPTION
Doh.  Missed one.  