### PR TITLE
Fix for the Cargo Rust Tool chain error

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -3,19 +3,16 @@ name: Docker
 on:
   pull_request:
     branches:
-      - main
+      - docker-build-fix-011825
   push:
     branches:
-      - main
+      - docker-build-fix-011825
     tags:
       - v*
   schedule:
     - cron: '0 16 * * *' # Every day at 16:00 UTC (~09:00 PT)
 
-
 jobs:
-  # Push container image to GitHub Packages and Docker Hub.
-  # See also https://docs.docker.com/docker-hub/builds/
   deploy:
     name: Docker image build
     runs-on: ubuntu-latest
@@ -31,8 +28,6 @@ jobs:
              sudo rm -f /swapfile
              sudo rm -rf /opt/hostedtoolcache
              sudo apt clean
-             #docker rmi $(docker image ls -aq)
-             # Remove Docker images if any exist
              if [ "$(docker image ls -aq)" ]; then
                 docker rmi $(docker image ls -aq)
              else
@@ -59,8 +54,8 @@ jobs:
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
 
-      - name: set default docker build version
-        run:  echo "IMAGE_TAG=nightly" >> $GITHUB_ENV
+      - name: Set default Docker build version
+        run: echo "IMAGE_TAG=nightly" >> $GITHUB_ENV
 
       # Log into container registries
       - name: Login to DockerHub
@@ -69,47 +64,48 @@ jobs:
           username: wildmeorg
           password: ${{ secrets.WBIA_WILDMEBOT_DOCKER_HUB_TOKEN }}
 
-      # Push tagged image (version tag + latest) to registries
+      # Push tagged image to registries
       - name: Tagged Docker Hub
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
         run: |
           VERSION=$(echo ${GITHUB_REF} | sed 's#.*/v##')
           echo "IMAGE_TAG=${VERSION}" >> $GITHUB_ENV
 
-      # Push bleeding-edge image (main tag) to registries
+      # Push bleeding-edge image to registries
       - name: Bleeding Edge Docker Hub
         if: github.ref == 'refs/heads/main'
-        run: |
-          echo "IMAGE_TAG=main" >> $GITHUB_ENV
+        run: echo "IMAGE_TAG=main" >> $GITHUB_ENV
 
-      # Push nightly image (nightly tag) to registries
+      # Push nightly image to registries
       - name: Nightly Docker Hub
         if: github.event_name == 'schedule'
-        run: |
-          echo "IMAGE_TAG=nightly" >> $GITHUB_ENV
+        run: echo "IMAGE_TAG=nightly" >> $GITHUB_ENV
 
-      # Build images
+      # Build and push images
       - name: Build Codex
         run: |
           docker buildx build \
               -t wildme/scoutbot:${{ env.IMAGE_TAG }} \
               --platform linux/amd64 \
               --push \
+              --cache-from=type=local,src=/tmp/.buildx-cache \
+              --cache-to=type=local,dest=/tmp/.buildx-cache \
               .
 
-      # Also push latest image
-      - name: Build Codex
+      - name: Also push latest image
         if: ${{ github.event_name == 'push'}}
         run: |
           docker buildx build \
               -t wildme/scoutbot:latest \
               --platform linux/amd64 \
               --push \
+              --cache-from=type=local,src=/tmp/.buildx-cache \
+              --cache-to=type=local,dest=/tmp/.buildx-cache \
               .
+
       - name: Trigger Scout Build
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GHCR_PAT  }}
-          repository: WildMeOrg/scout  # Adjust to the actual repository name
-          event-type: build-trigger  # You can choose any custom event type
-
+          token: ${{ secrets.GHCR_PAT }}
+          repository: WildMeOrg/scout
+          event-type: build-trigger

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -3,10 +3,10 @@ name: Docker
 on:
   pull_request:
     branches:
-      - docker-build-fix-011825
+      - main
   push:
     branches:
-      - docker-build-fix-011825
+      - main
     tags:
       - v*
   schedule:

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -40,14 +40,14 @@ jobs:
         with:
           exclude: "scoutbot/*/models/pytorch/"
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v3.3.0
         name: Set up QEMU
         id: qemu
         with:
           image: tonistiigi/binfmt:latest
           platforms: all
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3.8.0
         name: Set up Docker Buildx
         id: buildx
 

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -82,7 +82,7 @@ jobs:
         run: echo "IMAGE_TAG=nightly" >> $GITHUB_ENV
 
       # Build and push images
-      - name: Build Codex
+      - name: Build Scoutbot
         run: |
           docker buildx build \
               -t wildme/scoutbot:${{ env.IMAGE_TAG }} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu20.04
 
+# Set environment variables
 ENV GRADIO_SERVER_NAME=0.0.0.0
-
 ENV GRADIO_SERVER_PORT=7860
+ENV PATH="/root/.cargo/bin:$PATH"  # Highlighted: Added Rust's bin directory to PATH
 
 # Install apt packages
 RUN set -ex \
@@ -10,16 +11,25 @@ RUN set -ex \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         python3-dev \
         python3-pip \
+        curl \  #  Added curl for Rust installation
+        build-essential \  # Added build tools for compiling extensions
  && rm -rf /var/cache/apt \
  && rm -rf /var/lib/apt/lists/*
 
+# Install Rust toolchain as the docker build is failing due to missing Rust Tool Chain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+ && rustc --version  # Verify Rust installation
+
 WORKDIR /code
 
+# Copy project files
 COPY ./ /code
 
+# Install Python dependencies
 RUN pip3 install --no-cache-dir -r requirements.txt \
  && pip3 install -e . \
  && pip3 uninstall -y onnxruntime \
  && pip3 install --no-cache-dir onnxruntime-gpu
 
+# Default command
 CMD python3 app2.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,22 +3,26 @@ FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu20.04
 # Set environment variables
 ENV GRADIO_SERVER_NAME=0.0.0.0
 ENV GRADIO_SERVER_PORT=7860
-ENV PATH="/root/.cargo/bin:$PATH"  # Highlighted: Added Rust's bin directory to PATH
+#  Added Rust's bin directory to PATH
+ENV PATH="/root/.cargo/bin:$PATH" 
 
 # Install apt packages
+# Added curl for Rust installation
+# Added build tools for compiling extensions
 RUN set -ex \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         python3-dev \
         python3-pip \
-        curl \  #  Added curl for Rust installation
-        build-essential \  # Added build tools for compiling extensions
+        curl \ 
+        build-essential \  
  && rm -rf /var/cache/apt \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Rust toolchain as the docker build is failing due to missing Rust Tool Chain
+# Verify Rust installation
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
- && rustc --version  # Verify Rust installation
+ && rustc --version 
 
 WORKDIR /code
 


### PR DESCRIPTION
Fixing the Cargo Rust Tool chain error:

#10 32.00     Cargo, the Rust package manager, is not installed or is not on PATH.
#10 32.00     This package requires Rust and Cargo to compile extensions. Install it through
#10 32.00     the system's package manager or via https://rustup.rs/
#10 32.00     
#10 32.00     Checking for Rust toolchain....